### PR TITLE
feat: add missing tagging support

### DIFF
--- a/google/cloud/spanner_v1/batch.py
+++ b/google/cloud/spanner_v1/batch.py
@@ -166,6 +166,10 @@ class Batch(_BatchBase):
             request_options = RequestOptions()
         elif type(request_options) == dict:
             request_options = RequestOptions(request_options)
+        request_options.transaction_tag = self.transaction_tag
+
+        # Request tags are not supported for commit requests.
+        request_options.request_tag = None
 
         request = CommitRequest(
             session=self._session.name,

--- a/google/cloud/spanner_v1/batch.py
+++ b/google/cloud/spanner_v1/batch.py
@@ -32,6 +32,9 @@ class _BatchBase(_SessionWrapper):
     :param session: the session used to perform the commit
     """
 
+    transaction_tag = None
+    _read_only = False
+
     def __init__(self, session):
         super(_BatchBase, self).__init__(session)
         self._mutations = []

--- a/google/cloud/spanner_v1/database.py
+++ b/google/cloud/spanner_v1/database.py
@@ -801,12 +801,19 @@ class BatchCheckout(object):
     def __init__(self, database, request_options=None):
         self._database = database
         self._session = self._batch = None
-        self._request_options = request_options
+        if request_options is None:
+            self._request_options = RequestOptions()
+        elif type(request_options) == dict:
+            self._request_options = RequestOptions(request_options)
+        else:
+            self._request_options = request_options
 
     def __enter__(self):
         """Begin ``with`` block."""
         session = self._session = self._database._pool.get()
         batch = self._batch = Batch(session)
+        if self._request_options.transaction_tag:
+            batch.transaction_tag = self._request_options.transaction_tag
         return batch
 
     def __exit__(self, exc_type, exc_val, exc_tb):

--- a/google/cloud/spanner_v1/session.py
+++ b/google/cloud/spanner_v1/session.py
@@ -346,8 +346,7 @@ class Session(object):
         while True:
             if self._transaction is None:
                 txn = self.transaction()
-                if transaction_tag is not None:
-                    txn.transaction_tag = transaction_tag
+                txn.transaction_tag = transaction_tag
             else:
                 txn = self._transaction
             if txn._transaction_id is None:

--- a/google/cloud/spanner_v1/snapshot.py
+++ b/google/cloud/spanner_v1/snapshot.py
@@ -193,12 +193,11 @@ class _SnapshotBase(_SessionWrapper):
         elif type(request_options) == dict:
             request_options = RequestOptions(request_options)
 
-        if not self._read_only:
-            # It's a Transaction request and not running on a Snapshot.
-            if self.transaction_tag is not None:
-                request_options.transaction_tag = self.transaction_tag
-        else:
+        if self._read_only:
+            # Transaction tags are not supported for read only transactions.
             request_options.transaction_tag = None
+        else:
+            request_options.transaction_tag = self.transaction_tag
 
         request = ReadRequest(
             session=self._session.name,
@@ -329,10 +328,9 @@ class _SnapshotBase(_SessionWrapper):
         elif type(request_options) == dict:
             request_options = RequestOptions(request_options)
         if self._read_only:
-            # It's a execute request on a Spanshot.
+            # Transaction tags are not supported for read only transactions.
             request_options.transaction_tag = None
-        elif self.transaction_tag is not None:
-            # It's a Transaction request and not running on a Snapshot.
+        else:
             request_options.transaction_tag = self.transaction_tag
 
         request = ExecuteSqlRequest(

--- a/google/cloud/spanner_v1/transaction.py
+++ b/google/cloud/spanner_v1/transaction.py
@@ -46,9 +46,7 @@ class Transaction(_SnapshotBase, _BatchBase):
     """Timestamp at which the transaction was successfully committed."""
     rolled_back = False
     commit_stats = None
-    transaction_tag = None
     _multi_use = True
-    _read_only = False
     _execute_sql_count = 0
 
     def __init__(self, session):

--- a/google/cloud/spanner_v1/transaction.py
+++ b/google/cloud/spanner_v1/transaction.py
@@ -155,6 +155,9 @@ class Transaction(_SnapshotBase, _BatchBase):
         if self.transaction_tag is not None:
             request_options.transaction_tag = self.transaction_tag
 
+        # Request tags are not supported for commit requests.
+        request_options.request_tag = None
+
         request = CommitRequest(
             session=self._session.name,
             mutations=self._mutations,
@@ -275,6 +278,7 @@ class Transaction(_SnapshotBase, _BatchBase):
             request_options = RequestOptions()
         elif type(request_options) == dict:
             request_options = RequestOptions(request_options)
+        request_options.transaction_tag = self.transaction_tag
 
         trace_attributes = {"db.statement": dml}
 
@@ -353,6 +357,7 @@ class Transaction(_SnapshotBase, _BatchBase):
             request_options = RequestOptions()
         elif type(request_options) == dict:
             request_options = RequestOptions(request_options)
+        request_options.transaction_tag = self.transaction_tag
 
         trace_attributes = {
             # Get just the queries from the DML statement batch

--- a/tests/unit/test_batch.py
+++ b/tests/unit/test_batch.py
@@ -274,7 +274,13 @@ class TestBatch(_BaseTest, OpenTelemetryBase):
         expected_request_options.transaction_tag = self.TRANSACTION_TAG
         expected_request_options.request_tag = None
 
-        (session, mutations, single_use_txn, actual_request_options, metadata) = api._committed
+        (
+            session,
+            mutations,
+            single_use_txn,
+            actual_request_options,
+            metadata,
+        ) = api._committed
         self.assertEqual(session, self.SESSION_NAME)
         self.assertEqual(mutations, batch._mutations)
         self.assertIsInstance(single_use_txn, TransactionOptions)

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -1576,7 +1576,9 @@ class TestBatchCheckout(_BaseTest):
         pool = database._pool = _Pool()
         session = _Session(database)
         pool.put(session)
-        checkout = self._make_one(database, request_options={"transaction_tag": self.TRANSACTION_TAG})
+        checkout = self._make_one(
+            database, request_options={"transaction_tag": self.TRANSACTION_TAG}
+        )
 
         with checkout as batch:
             self.assertIsNone(pool._session)

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -1496,7 +1496,8 @@ class TestSession(OpenTelemetryBase):
 
         transaction_tag = "transaction_tag"
         return_value = session.run_in_transaction(
-            unit_of_work, "abc", some_arg="def", transaction_tag=transaction_tag)
+            unit_of_work, "abc", some_arg="def", transaction_tag=transaction_tag
+        )
 
         self.assertIsNone(session._transaction)
         self.assertEqual(len(called_with), 1)

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -1455,6 +1455,73 @@ class TestSession(OpenTelemetryBase):
         )
         database.logger.info.assert_not_called()
 
+    def test_run_in_transaction_w_transaction_tag(self):
+        import datetime
+        from google.cloud.spanner_v1 import CommitRequest
+        from google.cloud.spanner_v1 import CommitResponse
+        from google.cloud.spanner_v1 import (
+            Transaction as TransactionPB,
+            TransactionOptions,
+        )
+        from google.cloud._helpers import UTC
+        from google.cloud._helpers import _datetime_to_pb_timestamp
+        from google.cloud.spanner_v1.transaction import Transaction
+
+        TABLE_NAME = "citizens"
+        COLUMNS = ["email", "first_name", "last_name", "age"]
+        VALUES = [
+            ["phred@exammple.com", "Phred", "Phlyntstone", 32],
+            ["bharney@example.com", "Bharney", "Rhubble", 31],
+        ]
+        TRANSACTION_ID = b"FACEDACE"
+        transaction_pb = TransactionPB(id=TRANSACTION_ID)
+        now = datetime.datetime.utcnow().replace(tzinfo=UTC)
+        now_pb = _datetime_to_pb_timestamp(now)
+        commit_stats = CommitResponse.CommitStats(mutation_count=4)
+        response = CommitResponse(commit_timestamp=now_pb, commit_stats=commit_stats)
+        gax_api = self._make_spanner_api()
+        gax_api.begin_transaction.return_value = transaction_pb
+        gax_api.commit.return_value = response
+        database = self._make_database()
+        database.spanner_api = gax_api
+        session = self._make_one(database)
+        session._session_id = self.SESSION_ID
+
+        called_with = []
+
+        def unit_of_work(txn, *args, **kw):
+            called_with.append((txn, args, kw))
+            txn.insert(TABLE_NAME, COLUMNS, VALUES)
+            return 42
+
+        transaction_tag = "transaction_tag"
+        return_value = session.run_in_transaction(
+            unit_of_work, "abc", some_arg="def", transaction_tag=transaction_tag)
+
+        self.assertIsNone(session._transaction)
+        self.assertEqual(len(called_with), 1)
+        txn, args, kw = called_with[0]
+        self.assertIsInstance(txn, Transaction)
+        self.assertEqual(return_value, 42)
+        self.assertEqual(args, ("abc",))
+        self.assertEqual(kw, {"some_arg": "def"})
+
+        expected_options = TransactionOptions(read_write=TransactionOptions.ReadWrite())
+        gax_api.begin_transaction.assert_called_once_with(
+            session=self.SESSION_NAME,
+            options=expected_options,
+            metadata=[("google-cloud-resource-prefix", database.name)],
+        )
+        request = CommitRequest(
+            session=self.SESSION_NAME,
+            mutations=txn._mutations,
+            transaction_id=TRANSACTION_ID,
+            request_options=RequestOptions(transaction_tag=transaction_tag),
+        )
+        gax_api.commit.assert_called_once_with(
+            request=request, metadata=[("google-cloud-resource-prefix", database.name)],
+        )
+
     def test_delay_helper_w_no_delay(self):
         from google.cloud.spanner_v1.session import _delay_until_retry
 

--- a/tests/unit/test_snapshot.py
+++ b/tests/unit/test_snapshot.py
@@ -509,7 +509,8 @@ class Test_SnapshotBase(OpenTelemetryBase):
             expected_limit = LIMIT
 
         # Transaction tag is ignored for read request.
-        request_options.transaction_tag = None
+        expected_request_options = request_options
+        expected_request_options.transaction_tag = None
 
         expected_request = ReadRequest(
             session=self.SESSION_NAME,
@@ -520,7 +521,7 @@ class Test_SnapshotBase(OpenTelemetryBase):
             index=INDEX,
             limit=expected_limit,
             partition_token=partition,
-            request_options=request_options,
+            request_options=expected_request_options,
         )
         api.streaming_read.assert_called_once_with(
             request=expected_request,
@@ -733,7 +734,8 @@ class Test_SnapshotBase(OpenTelemetryBase):
 
         if derived._read_only:
             # Transaction tag is ignored for read only requests.
-            request_options.transaction_tag = None
+            expected_request_options = request_options
+            expected_request_options.transaction_tag = None
 
         expected_request = ExecuteSqlRequest(
             session=self.SESSION_NAME,
@@ -743,7 +745,7 @@ class Test_SnapshotBase(OpenTelemetryBase):
             param_types=PARAM_TYPES,
             query_mode=MODE,
             query_options=expected_query_options,
-            request_options=request_options,
+            request_options=expected_request_options,
             partition_token=partition,
             seqno=sql_count,
         )

--- a/tests/unit/test_transaction.py
+++ b/tests/unit/test_transaction.py
@@ -349,7 +349,9 @@ class TestTransaction(OpenTelemetryBase):
         session_id, mutations, txn_id, actual_request_options, metadata = api._committed
 
         if request_options is None:
-            expected_request_options = RequestOptions(transaction_tag=self.TRANSACTION_TAG)
+            expected_request_options = RequestOptions(
+                transaction_tag=self.TRANSACTION_TAG
+            )
         elif type(request_options) == dict:
             expected_request_options = RequestOptions(request_options)
             expected_request_options.transaction_tag = self.TRANSACTION_TAG

--- a/tests/unit/test_transaction.py
+++ b/tests/unit/test_transaction.py
@@ -334,8 +334,7 @@ class TestTransaction(OpenTelemetryBase):
         session = _Session(database)
         transaction = self._make_one(session)
         transaction._transaction_id = self.TRANSACTION_ID
-        if self.TRANSACTION_TAG:
-            transaction.transaction_tag = self.TRANSACTION_TAG
+        transaction.transaction_tag = self.TRANSACTION_TAG
 
         if mutate:
             transaction.delete(TABLE_NAME, keyset)
@@ -347,18 +346,24 @@ class TestTransaction(OpenTelemetryBase):
         self.assertEqual(transaction.committed, now)
         self.assertIsNone(session._transaction)
 
-        session_id, mutations, txn_id, req_options, metadata = api._committed
+        session_id, mutations, txn_id, actual_request_options, metadata = api._committed
+
+        if request_options is None:
+            expected_request_options = RequestOptions(transaction_tag=self.TRANSACTION_TAG)
+        elif type(request_options) == dict:
+            expected_request_options = RequestOptions(request_options)
+            expected_request_options.transaction_tag = self.TRANSACTION_TAG
+            expected_request_options.request_tag = None
+        else:
+            expected_request_options = request_options
+            expected_request_options.transaction_tag = self.TRANSACTION_TAG
+            expected_request_options.request_tag = None
 
         self.assertEqual(session_id, session.name)
         self.assertEqual(txn_id, self.TRANSACTION_ID)
         self.assertEqual(mutations, transaction._mutations)
         self.assertEqual(metadata, [("google-cloud-resource-prefix", database.name)])
-        if req_options and self.TRANSACTION_TAG:
-            self.assertEqual(req_options.transaction_tag, self.TRANSACTION_TAG)
-        elif request_options and request_options.transaction_tag:
-            self.assertEqual(
-                req_options.transaction_tag, request_options.transaction_tag
-            )
+        self.assertEqual(actual_request_options, expected_request_options)
 
         if return_commit_stats:
             self.assertEqual(transaction.commit_stats.mutation_count, 4)
@@ -487,6 +492,7 @@ class TestTransaction(OpenTelemetryBase):
         session = _Session(database)
         transaction = self._make_one(session)
         transaction._transaction_id = self.TRANSACTION_ID
+        transaction.transaction_tag = self.TRANSACTION_TAG
         transaction._execute_sql_count = count
 
         if request_options is None:
@@ -517,6 +523,8 @@ class TestTransaction(OpenTelemetryBase):
             expected_query_options = _merge_query_options(
                 expected_query_options, query_options
             )
+        expected_request_options = request_options
+        expected_request_options.transaction_tag = self.TRANSACTION_TAG
 
         expected_request = ExecuteSqlRequest(
             session=self.SESSION_NAME,
@@ -659,6 +667,7 @@ class TestTransaction(OpenTelemetryBase):
         session = _Session(database)
         transaction = self._make_one(session)
         transaction._transaction_id = self.TRANSACTION_ID
+        transaction.transaction_tag = self.TRANSACTION_TAG
         transaction._execute_sql_count = count
 
         if request_options is None:
@@ -688,13 +697,15 @@ class TestTransaction(OpenTelemetryBase):
             ExecuteBatchDmlRequest.Statement(sql=update_dml),
             ExecuteBatchDmlRequest.Statement(sql=delete_dml),
         ]
+        expected_request_options = request_options
+        expected_request_options.transaction_tag = self.TRANSACTION_TAG
 
         expected_request = ExecuteBatchDmlRequest(
             session=self.SESSION_NAME,
             transaction=expected_transaction,
             statements=expected_statements,
             seqno=count,
-            request_options=request_options,
+            request_options=expected_request_options,
         )
         api.execute_batch_dml.assert_called_once_with(
             request=expected_request,

--- a/tests/unit/test_transaction.py
+++ b/tests/unit/test_transaction.py
@@ -393,13 +393,6 @@ class TestTransaction(OpenTelemetryBase):
         request_options = RequestOptions(transaction_tag="tag-1-1",)
         self._commit_helper(request_options=request_options)
 
-    def test_commit_w_transaction_tag_overridden_success(self):
-        trx_tag_back = self.TRANSACTION_TAG
-        self.TRANSACTION_TAG = None
-        request_options = RequestOptions(transaction_tag="trx-tag",)
-        self._commit_helper(request_options=request_options)
-        self.TRANSACTION_TAG = trx_tag_back
-
     def test_commit_w_request_and_transaction_tag_success(self):
         request_options = RequestOptions(
             request_tag="tag-1", transaction_tag="tag-1-1",


### PR DESCRIPTION
This PR adds support for setting a transaction tag on batch transactions:
```
with database.batch(request_options={"transaction_tag": "tag-1"}):
  batch.insert()
  ...
```

It also prevents users from setting a transaction tag incorrectly
```
def unit_of_work(transaction):
  transaction.execute_sql("SELECT 1", request_options={"transaction_tag": "incorrect_tag"})  # This tag will be ignored.
  

# This tag will be used for all requests made in this transaction.
database.run_in_transaction(unit_of_work, transaction_tag="correct_tag") 
```
